### PR TITLE
Redirect MED subject to dedicated module

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,10 @@
     }
 
     async function startSubject(code){
+      if (code === 'MED') {
+        window.location.href = './subjects/medicine/';
+        return;
+      }
       const url = URLS.subjects[code];
       if(!url){ alert('Subject not set up yet.'); return; }
       const data = await fetchJSON(url);


### PR DESCRIPTION
## Summary
- update the startSubject handler to send MED to the dedicated medicine module
- keep existing JSON-driven loading for other subjects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f0e206b0833090abd29a1d584c00