### PR TITLE
Add Firebase auth integration and role-based gating

### DIFF
--- a/core/figural/index.html
+++ b/core/figural/index.html
@@ -49,6 +49,87 @@
       padding: 22px 0 10px;
     }
 
+    .top-nav-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+
+    .nav-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .auth-panel {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .auth-panel .btn {
+      font-size: 13px;
+      padding: 8px 12px;
+      border-radius: 8px;
+    }
+
+    .auth-panel .btn.is-loading {
+      opacity: 0.7;
+      pointer-events: none;
+    }
+
+    .user-chip {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      background: rgba(17, 24, 39, 0.08);
+      border-radius: 999px;
+      padding: 6px 10px;
+    }
+
+    .user-chip__meta {
+      display: flex;
+      flex-direction: column;
+      line-height: 1;
+    }
+
+    .user-chip__meta strong {
+      font-size: 13px;
+    }
+
+    .user-chip__meta small {
+      font-size: 11px;
+      color: var(--sf-muted);
+    }
+
+    .user-chip__signout {
+      font-size: 11px;
+      padding: 6px 10px;
+      border-radius: 8px;
+    }
+
+    .user-chip__admin {
+      font-size: 11px;
+      color: var(--sf-muted);
+    }
+
+    .auth-status-wrap {
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 0 24px 10px;
+    }
+
+    .auth-status {
+      margin: 0;
+      padding: 8px 12px;
+      background: rgba(17, 24, 39, 0.08);
+      border-radius: 12px;
+      font-size: 12px;
+      color: var(--sf-muted);
+      text-align: right;
+    }
+
     .wrap {
       width: 100%;
       max-width: 1080px;
@@ -71,6 +152,22 @@
     .back-link:hover {
       transform: translateY(-1px);
       background: rgba(17, 24, 39, 0.12);
+    }
+
+    .btn {
+      appearance: none;
+      border: 1px solid rgba(17, 24, 39, 0.12);
+      background: #ffffff;
+      padding: 8px 12px;
+      border-radius: 10px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: transform 0.1s ease, box-shadow 0.15s ease, background 0.15s ease;
+    }
+
+    .btn:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px rgba(15, 17, 21, 0.12);
     }
 
     .page-header {
@@ -110,6 +207,47 @@
       box-shadow: var(--sf-shadow);
       margin-bottom: 26px;
       border: 1px solid rgba(17, 24, 39, 0.06);
+    }
+
+    .access-notice {
+      margin: 20px 0;
+      padding: 18px 20px;
+      border-radius: 16px;
+      background: rgba(220, 38, 38, 0.08);
+      border: 1px solid rgba(220, 38, 38, 0.3);
+      color: #b91c1c;
+      font-weight: 500;
+    }
+
+    .admin-tools {
+      margin: 0 0 26px 0;
+      padding: 20px 22px;
+      border-radius: 16px;
+      background: #fff4f4;
+      border: 1px solid rgba(227, 6, 19, 0.2);
+      box-shadow: var(--sf-shadow);
+    }
+
+    .admin-tools h2 {
+      margin: 0 0 8px 0;
+      font-size: 18px;
+    }
+
+    .admin-tools p {
+      margin: 0 0 12px 0;
+      font-size: 14px;
+      color: var(--sf-muted);
+    }
+
+    .admin-tools ul {
+      margin: 0;
+      padding-left: 20px;
+      font-size: 14px;
+      color: var(--sf-muted);
+    }
+
+    .admin-tools li {
+      margin-bottom: 6px;
     }
 
     .status-line {
@@ -376,6 +514,22 @@
         margin-bottom: 20px;
       }
 
+      .top-nav-inner {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+      }
+
+      .nav-actions {
+        width: 100%;
+        justify-content: space-between;
+      }
+
+      .user-chip {
+        width: 100%;
+        justify-content: space-between;
+      }
+
       .question-card {
         padding: 22px;
       }
@@ -394,8 +548,24 @@
 <body>
   <div class="page">
     <nav class="top-nav">
-      <div class="wrap">
+      <div class="wrap top-nav-inner">
         <a class="back-link" href="../../index.html">← Back to Modules</a>
+        <div class="nav-actions">
+          <div class="auth-panel">
+            <button class="btn" data-auth-sign-in>Sign in</button>
+            <div class="user-chip" data-auth-user hidden>
+              <div class="user-chip__meta">
+                <strong data-auth-name>Guest</strong>
+                <small data-auth-role>Guest</small>
+              </div>
+              <small class="user-chip__admin" data-admin-id hidden></small>
+              <button class="btn user-chip__signout" data-auth-sign-out>Sign out</button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="auth-status-wrap">
+        <p class="auth-status" data-auth-status hidden></p>
       </div>
     </nav>
 
@@ -416,6 +586,20 @@
         <p id="statusLine" class="status-line">Loading question bank…</p>
       </section>
 
+      <section id="accessNotice" class="access-notice" hidden>
+        Access restricted. Sign in with a member, staff, or admin account to continue.
+      </section>
+
+      <section id="adminTools" class="admin-tools" data-requires-role="admin" hidden>
+        <h2>Admin quick actions</h2>
+        <p>Use these shortcuts to maintain the figural sequences bank:</p>
+        <ul>
+          <li>Upload new matrix sets to <code>data/core/fig.json</code>.</li>
+          <li>Archive outdated prompts after publishing updated explanations.</li>
+          <li>Share the admin ID with trusted staff only: <span data-admin-id></span>.</li>
+        </ul>
+      </section>
+
       <section id="questionList" class="question-list" aria-live="polite">
         <div id="loadingState" class="loading-state">Preparing tasks…</div>
       </section>
@@ -424,14 +608,63 @@
     </main>
   </div>
 
+  <script type="module" src="../../scripts/auth-controller.js"></script>
   <script type="module">
+    import { requireRole, subscribeToAuthChanges } from '../../scripts/auth.js';
+
     const DATA_URL = '../../data/core/fig.json';
     const MAX_QUESTIONS = 20;
+    const ALLOWED_ROLES = ['admin', 'staff', 'member'];
 
     const questionList = document.getElementById('questionList');
     const statusLine = document.getElementById('statusLine');
     const errorBox = document.getElementById('errorMessage');
     const loadingState = document.getElementById('loadingState');
+    const accessNotice = document.getElementById('accessNotice');
+    let hasLoadedQuestions = false;
+    let hasAccess = false;
+
+    const renderAccessNotice = (message) => {
+      if (!accessNotice) return;
+      if (message) {
+        accessNotice.textContent = message;
+        accessNotice.hidden = false;
+      } else {
+        accessNotice.hidden = true;
+      }
+    };
+
+    const showAccessDenied = (state) => {
+      const role = (state.profile?.role ?? 'guest').toLowerCase();
+      const message = state.user
+        ? `Your ${role} account does not have permission to open this module.`
+        : 'Sign in with a member, staff, or admin account to continue.';
+      renderAccessNotice(message);
+      if (statusLine) {
+        statusLine.textContent = 'Access restricted to member accounts and above.';
+      }
+      if (loadingState) {
+        loadingState.textContent = 'Restricted content. Sign in to continue.';
+      }
+      if (questionList) {
+        questionList.innerHTML = '';
+      }
+      hasAccess = false;
+      hasLoadedQuestions = false;
+    };
+
+    const showAccessGranted = () => {
+      renderAccessNotice('');
+      hasAccess = true;
+      if (statusLine && statusLine.textContent.startsWith('Access restricted')) {
+        statusLine.textContent = 'Loading question bank…';
+      }
+    };
+
+    const ensureQuestions = async () => {
+      if (!hasAccess || hasLoadedQuestions) return;
+      await loadQuestions();
+    };
 
     const normaliseId = (value) => (value === undefined || value === null ? null : String(value));
 
@@ -727,6 +960,7 @@
     };
 
     const loadQuestions = async () => {
+      if (!hasAccess) return;
       try {
         const response = await fetch(DATA_URL, { cache: 'no-store' });
         if (!response.ok) {
@@ -753,6 +987,7 @@
         statusLine.textContent = `Displaying ${countText}. Refresh the page to load a new random set.`;
 
         selected.forEach((question, index) => renderQuestion(question, index));
+        hasLoadedQuestions = true;
       } catch (error) {
         console.error(error);
         statusLine.textContent = 'Unable to load questions right now.';
@@ -761,10 +996,29 @@
         if (loadingState) {
           loadingState.textContent = 'Unable to load questions.';
         }
+        hasLoadedQuestions = false;
       }
     };
 
-    loadQuestions();
+    subscribeToAuthChanges((state) => {
+      const role = (state.profile?.role ?? 'guest').toLowerCase();
+      const allowed = ALLOWED_ROLES.includes(role);
+      if (!allowed) {
+        showAccessDenied(state);
+      } else {
+        showAccessGranted();
+        ensureQuestions();
+      }
+    }, { emitCurrent: false });
+
+    const initialCheck = await requireRole(ALLOWED_ROLES, {
+      onDenied: showAccessDenied,
+    });
+
+    if (initialCheck.allowed) {
+      showAccessGranted();
+      await ensureQuestions();
+    }
   </script>
 </body>
 </html>

--- a/core/math/index.html
+++ b/core/math/index.html
@@ -31,6 +31,114 @@
     padding: 20px;
 }
 
+        .top-nav {
+    margin: 0 auto 20px;
+    max-width: 900px;
+    padding: 0 20px;
+}
+
+.top-nav-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: #e30613;
+    text-decoration: none;
+    border: 2px solid #e30613;
+    padding: 8px 14px;
+    border-radius: 10px;
+    transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+
+.back-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 20px rgba(227, 6, 19, 0.2);
+}
+
+.nav-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.auth-panel {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.auth-panel .btn {
+    font-size: 13px;
+    padding: 8px 12px;
+    border-radius: 10px;
+}
+
+.auth-panel .btn.is-loading {
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.user-chip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: #fff;
+    border: 1px solid rgba(227, 6, 19, 0.4);
+    border-radius: 999px;
+    padding: 6px 10px;
+}
+
+.user-chip__meta {
+    display: flex;
+    flex-direction: column;
+    line-height: 1;
+}
+
+.user-chip__meta strong {
+    font-size: 13px;
+}
+
+.user-chip__meta small {
+    font-size: 11px;
+    color: #6b7280;
+}
+
+.user-chip__signout {
+    background: #fff;
+    color: #e30613;
+    border: 1px solid rgba(227, 6, 19, 0.4);
+    border-radius: 8px;
+    font-size: 11px;
+    padding: 6px 10px;
+}
+
+.user-chip__admin {
+    font-size: 11px;
+    color: #6b7280;
+}
+
+.auth-status {
+    max-width: 900px;
+    margin: 6px auto 0;
+    padding: 8px 12px;
+    background: #fff0f0;
+    border: 1px solid rgba(227, 6, 19, 0.25);
+    border-radius: 10px;
+    font-size: 12px;
+    color: #991b1b;
+}
+
+.auth-status[hidden] {
+    display: none;
+}
+
         .container {
             max-width: 900px;
             margin: 0 auto;
@@ -466,12 +574,25 @@
     </style>
 </head>
 <body>
-    <nav style="margin:20px; text-align:center;">
-  <a href="../../index.html" 
-     style="color:#e30613; text-decoration:none; font-weight:600; border:2px solid #e30613; padding:8px 12px; border-radius:8px;">
-     ← Back to Modules
-  </a>
-</nav>
+    <nav class="top-nav">
+        <div class="top-nav-inner">
+            <a class="back-link" href="../../index.html">← Back to Modules</a>
+            <div class="nav-actions">
+                <div class="auth-panel">
+                    <button class="btn" data-auth-sign-in>Sign in</button>
+                    <div class="user-chip" data-auth-user hidden>
+                        <div class="user-chip__meta">
+                            <strong data-auth-name>Guest</strong>
+                            <small data-auth-role>Guest</small>
+                        </div>
+                        <small class="user-chip__admin" data-admin-id hidden></small>
+                        <button class="btn user-chip__signout" data-auth-sign-out>Sign out</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <p class="auth-status" data-auth-status hidden></p>
+    </nav>
 
     <div class="container">
         <div class="header">
@@ -553,6 +674,7 @@
         <button class="btn btn-primary" onclick="backToMainMenu()">Back to Main Menu</button>
     </div>
 </div>
+    <script type="module" src="../../scripts/auth-controller.js"></script>
     <script>
         let currentDifficulty = '';
         let currentSolution = {};

--- a/data/userDirectory.json
+++ b/data/userDirectory.json
@@ -1,0 +1,29 @@
+{
+  "adminId": "sf-admin-001",
+  "users": [
+    {
+      "uid": "demo-admin-uid",
+      "email": "admin@studyfeeds.io",
+      "role": "admin",
+      "displayName": "Demo Admin"
+    },
+    {
+      "uid": "demo-staff-uid",
+      "email": "coach@studyfeeds.io",
+      "role": "staff",
+      "displayName": "Coaching Staff"
+    },
+    {
+      "uid": "demo-member-uid",
+      "email": "member@example.com",
+      "role": "member",
+      "displayName": "Member Learner"
+    },
+    {
+      "uid": "demo-student-uid",
+      "email": "student@example.com",
+      "role": "student",
+      "displayName": "Student User"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -43,6 +43,22 @@
     .top-nav-inner{
       display:flex;align-items:center;justify-content:space-between;gap:16px;
     }
+    .nav-actions{display:flex;align-items:center;gap:16px;}
+    .auth-panel{display:flex;align-items:center;gap:12px;}
+    .auth-panel .btn{font-size:13px;padding:10px 14px;border-radius:10px;}
+    .auth-panel .btn.is-loading{opacity:.7;pointer-events:none;}
+    .user-chip{display:flex;align-items:center;gap:12px;background:rgba(15,17,21,.08);border-radius:999px;padding:8px 12px;}
+    .user-chip__meta{display:flex;flex-direction:column;line-height:1;}
+    .user-chip__meta strong{font-size:14px;}
+    .user-chip__meta small{font-size:12px;color:var(--sf-muted);}
+    .user-chip__signout{font-size:12px;padding:6px 10px;border-radius:8px;}
+    .user-chip__admin{font-size:11px;color:var(--sf-muted);}
+    .auth-status-wrap{max-width:1080px;margin:0 auto;padding:0 24px;}
+    .auth-status{margin:0;padding:10px 16px;border-radius:14px;background:rgba(15,17,21,.08);font-size:12px;color:var(--sf-muted);text-align:right;}
+    .admin-banner{display:inline-flex;align-items:center;gap:6px;background:rgba(227,6,19,.12);color:var(--sf-red);padding:6px 12px;border-radius:999px;font-size:12px;font-weight:600;letter-spacing:.02em;text-transform:uppercase;}
+    .tile-locked{cursor:not-allowed;border-style:dashed;opacity:.75;}
+    .tile-locked:hover{transform:none;box-shadow:none;border-color:rgba(15,17,21,.1);}
+    .tile-locked::after{content:'\1f512';margin-left:8px;}
     .brand{
       display:flex;align-items:center;gap:12px;
     }
@@ -180,7 +196,11 @@
       .hero-actions{flex-direction:column;align-items:stretch;}
       .btn{width:100%;justify-content:center;}
       .top-nav-inner{flex-direction:column;align-items:flex-start;}
-      .nav-link{align-self:flex-end;}
+      .nav-actions{width:100%;flex-direction:column;align-items:flex-start;gap:10px;}
+      .auth-panel{width:100%;justify-content:space-between;gap:8px;}
+      .user-chip{width:100%;justify-content:space-between;}
+      .user-chip__meta{max-width:60%;}
+      .nav-link{align-self:flex-start;}
       .section{margin:60px 0 34px;}
     }
     @media (max-width:420px){
@@ -201,14 +221,32 @@
             <small>TestAS Practice</small>
           </div>
         </div>
-        <a class="nav-link" href="#module-selector">Browse modules ↓</a>
+        <div class="nav-actions">
+          <a class="nav-link" href="#module-selector">Browse modules ↓</a>
+          <div class="auth-panel">
+            <button class="btn btn-ghost auth-button" data-auth-sign-in>Sign in with Google</button>
+            <div class="user-chip" data-auth-user hidden>
+              <div class="user-chip__meta">
+                <strong data-auth-name>Guest</strong>
+                <small data-auth-role>Guest</small>
+              </div>
+              <small class="user-chip__admin" data-admin-id hidden></small>
+              <button class="btn btn-ghost user-chip__signout" data-auth-sign-out>Sign out</button>
+            </div>
+          </div>
+        </div>
       </div>
     </nav>
+
+    <div class="auth-status-wrap">
+      <p class="auth-status" data-auth-status hidden></p>
+    </div>
 
     <main>
       <section class="wrap hero">
         <div class="hero-content">
           <span class="eyebrow">Digital TestAS preparation</span>
+          <div class="admin-banner" data-requires-role="admin" hidden>🔑 Admin tools unlocked</div>
           <h1>Train with the same flow as the official exam day.</h1>
           <p class="lede">
             Build confidence for the digital TestAS by rehearsing every stage — from the Core Test with three reasoning
@@ -350,181 +388,7 @@
     </footer>
   </div>
 
-  <script type="module">
-    const URLS = {
-      modules: "./data/modules.json",
-      core: {
-        "CORE-FIG": "./data/core/fig.json",
-        "CORE-MATH": "./data/core/math.json",
-        "CORE-LAT": "./data/core/latin.json"
-      },
-      subjects: {
-        "ECON": "./data/subjects/econ.json"
-      }
-    };
-
-    const elCore = document.getElementById('core-grid');
-    const elSubj = document.getElementById('subject-grid');
-    const btnStartCore = document.getElementById('btn-start-core');
-    document.getElementById('year').textContent = new Date().getFullYear();
-
-    const fetchJSON = async (u)=>{ const r=await fetch(u); if(!r.ok) throw new Error('Fetch failed: '+u); return r.json(); };
-    const shuffle = (a)=>{ for(let i=a.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1)); [a[i],a[j]]=[a[j],a[i]];} return a; };
-
-    const modules = await fetchJSON(URLS.modules);
-
-    modules.core.subtests.sort((a,b)=>a.order-b.order).forEach(sub=>{
-      const tile = document.createElement('button');
-      tile.className = 'tile core';
-      tile.textContent = `${sub.order}. ${sub.name}`;
-      tile.onclick = ()=> startCore(sub.code);
-      elCore.appendChild(tile);
-    });
-
-    modules.subjects.forEach(s=>{
-      const tile = document.createElement('button');
-      tile.className = 'tile subject';
-      tile.textContent = s.name;
-      tile.onclick = ()=> startSubject(s.code);
-      elSubj.appendChild(tile);
-    });
-
-    btnStartCore.onclick = ()=> startCore(modules.core.subtests[0].code);
-
-    async function startCore(code){
-      if (code === 'CORE-FIG')  { window.location.href = './core/figural/'; return; }
-      if (code === 'CORE-MATH') { window.location.href = './core/math/';  return; }
-      if (code === 'CORE-LAT')  { window.location.href = './core/latin/'; return; }
-
-      const url = URLS.core[code];
-      if(!url){ alert('Subtest not set up yet.'); return; }
-      const data = await fetchJSON(url);
-      runQuiz(data.subtest, data.questions, {mode:'core'});
-    }
-
-    async function startSubject(code){
-      if (code === 'MED') {
-        window.location.href = './subjects/medicine/';
-        return;
-      }
-      const url = URLS.subjects[code];
-      if(!url){ alert('Subject not set up yet.'); return; }
-      const data = await fetchJSON(url);
-      const qs = shuffle(data.questions);
-      runQuiz(data.subject, qs, {mode:'subject'});
-    }
-
-    function runQuiz(title, questions, opts){
-      const container = document.querySelector('.page');
-      container.innerHTML = `
-        <div class="wrap">
-          <header style="display:flex;align-items:center;gap:12px;margin:30px 0 10px 0;">
-            <span class="dot" style="width:12px;height:12px;border-radius:50%;background:var(--sf-red);"></span>
-            <div class="brand" style="font-weight:700;font-size:18px;">
-              Study Feeds • TestAS Practice
-            </div>
-            <span class="tag" style="margin-left:auto;background:var(--sf-red);color:#fff;padding:6px 12px;border-radius:999px;font-size:12px;font-weight:600;">
-              ${opts.mode==='core' ? 'Core' : 'Subject'}
-            </span>
-          </header>
-        </div>
-        <section class="wrap hero" style="margin-bottom:30px;">
-          <div class="hero-content">
-            <h1 style="font-size:32px;">${title.replace('CORE-','')}</h1>
-            <p class="muted" style="color:var(--sf-muted);">Question <span id="p-count">1</span> / ${questions.length}</p>
-            <div class="hero-actions">
-              <button class="btn" id="btn-back">← Back to Modules</button>
-            </div>
-          </div>
-          <div class="hero-visual" style="justify-content:center;">
-            <div class="stat" style="background:#fff;border-radius:16px;padding:22px 24px;box-shadow:var(--shadow-soft);">
-              <strong style="font-size:28px;color:var(--sf-dark);">Stay focused</strong>
-              <span>Work through one task at a time and review the explanation afterwards.</span>
-            </div>
-          </div>
-        </section>
-        <section class="wrap section" style="margin-top:0;">
-          <div class="module-panel" style="box-shadow:var(--shadow-soft);">
-            <div id="quiz"></div>
-          </div>
-        </section>
-        <footer style="margin:60px 0 30px;text-align:center;font-size:13px;color:var(--sf-muted);">
-          © ${new Date().getFullYear()} Study Feeds Practice
-        </footer>
-      `;
-      document.getElementById('btn-back').onclick = ()=> location.href = './';
-
-      let i=0, correct=0, review=[];
-      const mount = document.getElementById('quiz');
-      render();
-
-      function render(showExp=false){
-        const q = questions[i];
-        document.getElementById('p-count').textContent = i+1;
-        mount.innerHTML = `
-          <p style="font-weight:600;margin:0 0 8px 0;">${q.stem}</p>
-          ${q.image_url ? `<img src="${q.image_url}" alt="" style="max-width:100%;border:1px solid #eee;border-radius:12px;margin:12px 0;">` : ``}
-          <div style="display:grid;gap:12px;">
-            ${q.choices.map(c=>`
-              <button class="btn" data-l="${c.label}">
-                ${c.label ? `<strong>${c.label}.</strong> `:''}${c.text}
-              </button>
-            `).join('')}
-          </div>
-          ${showExp ? `
-            <div class="feature-card" style="margin-top:16px;background:#fff4f4;border:1px solid rgba(227,6,19,.18);">
-              <strong>Explanation</strong><br>${q.explanation || '—'}
-            </div>` : ``}
-        `;
-
-        mount.querySelectorAll('button[data-l]').forEach(btn=>{
-          btn.onclick = ()=>{
-            const choice = q.choices.find(x=>x.label===btn.dataset.l);
-            const ok = !!choice?.is_correct;
-            if(ok) correct++;
-            review.push({stem:q.stem, choice:choice?.label, ok, explanation:q.explanation});
-            render(true);
-            setTimeout(()=>{
-              i++;
-              if(i>=questions.length) return results();
-              render();
-            }, 750);
-          };
-        });
-      }
-
-      function results(){
-        mount.innerHTML = `
-          <div style="text-align:center;display:grid;gap:18px;">
-            <div>
-              <h3 style="margin:0 0 6px 0;">Result</h3>
-              <p style="margin:0;">You answered <strong>${correct}</strong> out of ${questions.length} correctly.</p>
-            </div>
-            <div class="hero-actions" style="justify-content:center;">
-              <button class="btn btn-primary" id="btn-review">Review explanations</button>
-              <button class="btn" id="btn-home">Back to Modules</button>
-            </div>
-          </div>
-        `;
-        document.getElementById('btn-home').onclick = ()=> location.href = './';
-        document.getElementById('btn-review').onclick = ()=>{
-          mount.innerHTML = `
-            ${review.map(r=>`
-              <div class="feature-card" style="margin-bottom:12px;">
-                <p style="margin:0 0 6px 0;">${r.stem}</p>
-                <p class="muted" style="margin:0 0 6px 0;color:${r.ok?'#0f5132':'#842029'};">
-                  ${r.ok ? '✅ Correct' : '❌ Wrong'} — Your choice: ${r.choice ?? '—'}
-                </p>
-                <div>${r.explanation || '—'}</div>
-              </div>
-            `).join('')}
-            <div class="hero-actions" style="margin-top:16px;">
-              <button class="btn" onclick="location.href='./'">Back to Modules</button>
-            </div>
-          `;
-        };
-      }
-    }
-  </script>
+  <script type="module" src="./scripts/auth-controller.js"></script>
+  <script type="module" src="./scripts/home.js"></script>
 </body>
 </html>

--- a/scripts/auth-controller.js
+++ b/scripts/auth-controller.js
@@ -1,0 +1,128 @@
+import { initAuth, signInWithGoogle, signOutUser, subscribeToAuthChanges } from './auth.js';
+
+const signInButtons = Array.from(document.querySelectorAll('[data-auth-sign-in]'));
+const signOutButtons = Array.from(document.querySelectorAll('[data-auth-sign-out]'));
+const userContainers = Array.from(document.querySelectorAll('[data-auth-user]'));
+const nameTargets = Array.from(document.querySelectorAll('[data-auth-name]'));
+const roleTargets = Array.from(document.querySelectorAll('[data-auth-role]'));
+const adminIdTargets = Array.from(document.querySelectorAll('[data-admin-id]'));
+const statusTargets = Array.from(document.querySelectorAll('[data-auth-status]'));
+
+function setSignInLoading(isLoading) {
+  signInButtons.forEach((button) => {
+    button.disabled = isLoading;
+    button.classList.toggle('is-loading', isLoading);
+    if (isLoading) {
+      button.dataset.loadingLabel = button.textContent;
+      button.textContent = 'Connecting…';
+    } else if (button.dataset.loadingLabel) {
+      button.textContent = button.dataset.loadingLabel;
+      delete button.dataset.loadingLabel;
+    }
+  });
+}
+
+function updateRoleVisibility(role) {
+  const normalisedRole = (role ?? 'guest').toLowerCase();
+  document.body.dataset.authRole = normalisedRole;
+
+  document.querySelectorAll('[data-requires-role]').forEach((element) => {
+    const roles = String(element.dataset.requiresRole || '')
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+
+    if (!roles.length) return;
+    const allowed = roles.includes(normalisedRole);
+    element.hidden = !allowed;
+  });
+}
+
+function updateStatusMessage(state) {
+  if (!statusTargets.length) return;
+  const { status, error } = state;
+  const message = (() => {
+    if (status === 'unavailable') {
+      return 'Authentication is currently unavailable. You can continue browsing as a guest.';
+    }
+    if (status === 'error') {
+      return error?.message || 'Authentication temporarily unavailable.';
+    }
+    return '';
+  })();
+
+  statusTargets.forEach((target) => {
+    target.textContent = message;
+    target.hidden = !message;
+  });
+}
+
+function updateSession(state) {
+  const { user, profile, status } = state;
+  const displayName = profile?.displayName || user?.displayName || user?.email || 'Guest';
+  const roleLabel = profile?.role ? profile.role.charAt(0).toUpperCase() + profile.role.slice(1) : 'Guest';
+
+  signInButtons.forEach((button) => {
+    button.hidden = Boolean(user);
+    button.disabled = status === 'unavailable';
+    button.title = status === 'unavailable'
+      ? 'Authentication is currently unavailable.'
+      : '';
+  });
+
+  signOutButtons.forEach((button) => {
+    button.hidden = !user;
+  });
+
+  userContainers.forEach((container) => {
+    container.hidden = !user;
+  });
+
+  nameTargets.forEach((target) => {
+    target.textContent = displayName;
+  });
+
+  roleTargets.forEach((target) => {
+    target.textContent = roleLabel;
+  });
+
+  adminIdTargets.forEach((target) => {
+    const adminId = profile?.adminId ?? '';
+    target.textContent = adminId ? `Admin ID: ${adminId}` : '';
+    target.hidden = !adminId;
+  });
+
+  updateRoleVisibility(profile?.role);
+  updateStatusMessage(state);
+}
+
+signInButtons.forEach((button) => {
+  button.addEventListener('click', async () => {
+    setSignInLoading(true);
+    try {
+      await signInWithGoogle();
+    } catch (error) {
+      console.error('Study Feeds: sign-in failed', error);
+      alert(error?.message || 'Unable to sign in right now.');
+    } finally {
+      setSignInLoading(false);
+    }
+  });
+});
+
+signOutButtons.forEach((button) => {
+  button.addEventListener('click', async () => {
+    try {
+      await signOutUser();
+    } catch (error) {
+      console.error('Study Feeds: sign-out failed', error);
+      alert('Sign-out did not complete. Please refresh and try again.');
+    }
+  });
+});
+
+subscribeToAuthChanges(updateSession);
+
+initAuth().catch((error) => {
+  console.error('Study Feeds: authentication initialisation failed', error);
+});

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,0 +1,320 @@
+import { FIREBASE_CONFIG, AUTH_PROVIDER_SETTINGS } from './config.js';
+import { getUserDirectory, findDirectoryEntry } from './user-directory.js';
+
+let initializeApp;
+let getAuth;
+let GoogleAuthProvider;
+let onAuthStateChanged;
+let signInWithPopupFn;
+let signOutFn;
+
+let firebaseApp = null;
+let firebaseAuth = null;
+let authProvider = null;
+let firebaseLoadPromise = null;
+let initializing = false;
+
+const listeners = new Set();
+const readyStatuses = new Set(['authenticated', 'anonymous', 'unavailable', 'error']);
+let isReady = false;
+let readyWaiters = [];
+
+const defaultProfile = () => ({
+  role: 'guest',
+  adminId: null,
+  displayName: null,
+  directoryEntry: null,
+  email: null,
+});
+
+let currentState = {
+  status: 'idle',
+  user: null,
+  profile: defaultProfile(),
+  directory: null,
+  error: null,
+  lastUpdated: Date.now(),
+};
+
+function resolveReady(state) {
+  if (!isReady && readyStatuses.has(state.status)) {
+    isReady = true;
+    const waiters = readyWaiters;
+    readyWaiters = [];
+    waiters.forEach((resolve) => resolve(state));
+  }
+}
+
+function persistState(state) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (state.user) {
+      const payload = {
+        user: state.user,
+        profile: state.profile,
+      };
+      window.localStorage.setItem(
+        AUTH_PROVIDER_SETTINGS.sessionStorageKey,
+        JSON.stringify(payload)
+      );
+    } else {
+      window.localStorage.removeItem(AUTH_PROVIDER_SETTINGS.sessionStorageKey);
+    }
+
+    if (state.profile?.adminId) {
+      window.localStorage.setItem(AUTH_PROVIDER_SETTINGS.adminStorageKey, state.profile.adminId);
+    } else {
+      window.localStorage.removeItem(AUTH_PROVIDER_SETTINGS.adminStorageKey);
+    }
+  } catch (error) {
+    console.warn('Study Feeds: Unable to persist auth state', error);
+  }
+}
+
+function loadPersistedState() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(AUTH_PROVIDER_SETTINGS.sessionStorageKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    return {
+      user: parsed.user ?? null,
+      profile: parsed.profile ?? defaultProfile(),
+    };
+  } catch (error) {
+    console.warn('Study Feeds: Unable to read stored auth state', error);
+    return null;
+  }
+}
+
+function setState(partial) {
+  const next = {
+    ...currentState,
+    ...partial,
+    profile: partial.profile ?? currentState.profile,
+    directory: partial.directory ?? currentState.directory,
+    error: partial.error ?? null,
+    lastUpdated: Date.now(),
+  };
+  currentState = next;
+  window.__SF_AUTH_STATE__ = next;
+  persistState(next);
+  listeners.forEach((callback) => {
+    try {
+      callback(next);
+    } catch (callbackError) {
+      console.error('Study Feeds: auth listener failed', callbackError);
+    }
+  });
+  resolveReady(next);
+  return next;
+}
+
+async function loadFirebaseModules() {
+  if (initializeApp && getAuth && GoogleAuthProvider) return;
+  if (firebaseLoadPromise) return firebaseLoadPromise;
+  firebaseLoadPromise = Promise.all([
+    import('https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js'),
+    import('https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js'),
+  ])
+    .then(([appModule, authModule]) => {
+      initializeApp = appModule.initializeApp;
+      getAuth = authModule.getAuth;
+      GoogleAuthProvider = authModule.GoogleAuthProvider;
+      onAuthStateChanged = authModule.onAuthStateChanged;
+      signInWithPopupFn = authModule.signInWithPopup;
+      signOutFn = authModule.signOut;
+    })
+    .catch((error) => {
+      firebaseLoadPromise = null;
+      throw error;
+    });
+  return firebaseLoadPromise;
+}
+
+function sanitizeFirebaseUser(user) {
+  if (!user) return null;
+  return {
+    uid: user.uid ?? null,
+    email: user.email ?? null,
+    displayName: user.displayName ?? null,
+    photoURL: user.photoURL ?? null,
+  };
+}
+
+function createProfileFromDirectory(user, directory) {
+  const adminId = directory?.adminId ?? currentState.profile?.adminId ?? null;
+  if (!user) {
+    return {
+      ...defaultProfile(),
+      adminId,
+    };
+  }
+
+  const entry = findDirectoryEntry(user, directory);
+  const fallbackRole = AUTH_PROVIDER_SETTINGS.defaultRole ?? 'student';
+  const role = entry?.role ?? fallbackRole;
+  const displayName = entry?.displayName ?? user.displayName ?? (user.email ? user.email.split('@')[0] : null);
+  const email = user.email ?? entry?.email ?? null;
+
+  return {
+    role,
+    adminId,
+    displayName,
+    directoryEntry: entry ?? null,
+    email,
+  };
+}
+
+async function handleAuthState(firebaseUser) {
+  try {
+    let directory = currentState.directory;
+    try {
+      directory = await getUserDirectory();
+    } catch (directoryError) {
+      console.warn('Study Feeds: user directory unavailable', directoryError);
+    }
+    const profile = createProfileFromDirectory(firebaseUser, directory);
+    setState({
+      status: firebaseUser ? 'authenticated' : 'anonymous',
+      user: sanitizeFirebaseUser(firebaseUser),
+      profile,
+      directory,
+      error: null,
+    });
+  } catch (error) {
+    setState({
+      status: 'error',
+      user: null,
+      profile: defaultProfile(),
+      error: { message: error.message },
+    });
+  }
+}
+
+export function subscribeToAuthChanges(callback, options = {}) {
+  const { emitCurrent = true } = options;
+  listeners.add(callback);
+  if (emitCurrent) {
+    try {
+      callback(currentState);
+    } catch (callbackError) {
+      console.error('Study Feeds: auth listener failed', callbackError);
+    }
+  }
+  return () => listeners.delete(callback);
+}
+
+export function getAuthState() {
+  return currentState;
+}
+
+export function whenAuthReady() {
+  if (isReady) {
+    return Promise.resolve(currentState);
+  }
+  return new Promise((resolve) => {
+    readyWaiters.push(resolve);
+  });
+}
+
+export async function initAuth() {
+  if (initializing) {
+    return whenAuthReady();
+  }
+  initializing = true;
+
+  setState({ status: 'initializing' });
+
+  const stored = loadPersistedState();
+  if (stored) {
+    setState({
+      user: stored.user ?? null,
+      profile: stored.profile ?? defaultProfile(),
+      status: stored.user ? 'authenticated' : 'anonymous',
+    });
+  }
+
+  try {
+    await loadFirebaseModules();
+  } catch (error) {
+    console.warn('Study Feeds: Firebase libraries could not be loaded', error);
+    const next = setState({
+      status: 'unavailable',
+      error: { message: error.message },
+    });
+    resolveReady(next);
+    return next;
+  }
+
+  if (!firebaseApp) {
+    firebaseApp = initializeApp(FIREBASE_CONFIG);
+  }
+  if (!firebaseAuth) {
+    firebaseAuth = getAuth(firebaseApp);
+  }
+  if (!authProvider) {
+    authProvider = new GoogleAuthProvider();
+    authProvider.setCustomParameters({ prompt: 'select_account' });
+  }
+
+  onAuthStateChanged(firebaseAuth, (user) => {
+    handleAuthState(user);
+  });
+
+  await handleAuthState(firebaseAuth.currentUser ?? null);
+  return whenAuthReady();
+}
+
+export async function signInWithGoogle() {
+  await initAuth();
+  if (!firebaseAuth || !authProvider || !signInWithPopupFn) {
+    throw new Error('Authentication provider is not available. Try again later.');
+  }
+  return signInWithPopupFn(firebaseAuth, authProvider);
+}
+
+export async function signOutUser() {
+  if (!firebaseAuth || !signOutFn) {
+    setState({
+      status: 'anonymous',
+      user: null,
+      profile: defaultProfile(),
+    });
+    return;
+  }
+  await signOutFn(firebaseAuth);
+}
+
+function normaliseRoles(roles) {
+  if (!Array.isArray(roles) || !roles.length) return null;
+  return roles.map((role) => String(role).toLowerCase());
+}
+
+export async function requireRole(roles, options = {}) {
+  const allowedRoles = normaliseRoles(roles);
+  await initAuth();
+  const state = await whenAuthReady();
+  const role = (state.profile?.role ?? 'guest').toLowerCase();
+  const allowed = !allowedRoles || allowedRoles.includes(role);
+
+  if (!allowed) {
+    if (typeof options.onDenied === 'function') {
+      try {
+        options.onDenied(state);
+      } catch (callbackError) {
+        console.error('Study Feeds: onDenied callback failed', callbackError);
+      }
+    }
+    if (options.redirectTo) {
+      window.location.href = options.redirectTo;
+    }
+  }
+
+  return { allowed, state };
+}
+
+export function currentUserRole() {
+  return currentState.profile?.role ?? 'guest';
+}

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,0 +1,19 @@
+export const FIREBASE_CONFIG = {
+  apiKey: "AIzaSyDemoKey1234567890abcdefghi",
+  authDomain: "studyfeeds-demo.firebaseapp.com",
+  projectId: "studyfeeds-demo",
+  storageBucket: "studyfeeds-demo.appspot.com",
+  messagingSenderId: "123456789012",
+  appId: "1:123456789012:web:abc123def456ghi789jkl",
+  measurementId: "G-DEMO12345"
+};
+
+export const AUTH_PROVIDER_SETTINGS = {
+  defaultRole: 'student',
+  sessionStorageKey: 'sf-auth-state',
+  adminStorageKey: 'sf-admin-id',
+  guardMessages: {
+    unauthorized: 'Sign in to continue.',
+    insufficientRole: 'Your account does not have permission to open this content.'
+  }
+};

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -1,0 +1,317 @@
+import { subscribeToAuthChanges } from './auth.js';
+
+const moduleGuards = new Map();
+const guardTargets = new Map();
+let currentRole = 'guest';
+
+function normaliseRoles(roles) {
+  return roles.map((role) => String(role).toLowerCase());
+}
+
+function registerModuleGuard(code, roles, message) {
+  moduleGuards.set(code, {
+    roles: normaliseRoles(roles),
+    message,
+  });
+  updateGuardForCode(code);
+}
+
+function attachGuardTarget(code, element) {
+  if (!guardTargets.has(code)) {
+    guardTargets.set(code, new Set());
+  }
+  guardTargets.get(code).add(element);
+  updateGuardForCode(code, element);
+}
+
+function updateGuardForCode(code, singleTarget) {
+  const guard = moduleGuards.get(code);
+  if (!guard) return;
+  const targets = singleTarget ? [singleTarget] : Array.from(guardTargets.get(code) ?? []);
+  const allowed = guard.roles.includes(currentRole);
+  targets.forEach((target) => {
+    target.classList.toggle('tile-locked', !allowed);
+    target.dataset.locked = allowed ? 'false' : 'true';
+    target.setAttribute('aria-disabled', allowed ? 'false' : 'true');
+    if (!allowed && guard.message) {
+      target.title = guard.message;
+    } else {
+      target.removeAttribute('title');
+    }
+  });
+}
+
+function updateAllGuards() {
+  moduleGuards.forEach((_guard, code) => updateGuardForCode(code));
+}
+
+function canAccessModule(code) {
+  const guard = moduleGuards.get(code);
+  if (!guard) return true;
+  return guard.roles.includes(currentRole);
+}
+
+function guardMessage(code) {
+  return moduleGuards.get(code)?.message ?? 'This module is restricted.';
+}
+
+registerModuleGuard(
+  'CORE-FIG',
+  ['admin', 'staff', 'member'],
+  'Sign in with a member, staff, or admin account to unlock figural sequences.'
+);
+
+subscribeToAuthChanges((state) => {
+  currentRole = (state.profile?.role ?? 'guest').toLowerCase();
+  updateAllGuards();
+});
+
+const URLS = {
+  modules: './data/modules.json',
+  core: {
+    'CORE-FIG': './data/core/fig.json',
+    'CORE-MATH': './data/core/math.json',
+    'CORE-LAT': './data/core/latin.json',
+  },
+  subjects: {
+    ECON: './data/subjects/econ.json',
+  },
+};
+
+const elCore = document.getElementById('core-grid');
+const elSubj = document.getElementById('subject-grid');
+const btnStartCore = document.getElementById('btn-start-core');
+const yearEl = document.getElementById('year');
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}
+
+const fetchJSON = async (url) => {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Fetch failed: ${url}`);
+  return response.json();
+};
+
+const shuffle = (array) => {
+  for (let i = array.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+};
+
+const modules = await fetchJSON(URLS.modules);
+
+modules.core.subtests
+  .sort((a, b) => a.order - b.order)
+  .forEach((sub) => {
+    const tile = document.createElement('button');
+    tile.type = 'button';
+    tile.className = 'tile core';
+    tile.dataset.moduleCode = sub.code;
+    tile.textContent = `${sub.order}. ${sub.name}`;
+    tile.addEventListener('click', (event) => {
+      event.preventDefault();
+      startCore(sub.code);
+    });
+    elCore?.appendChild(tile);
+    attachGuardTarget(sub.code, tile);
+  });
+
+modules.subjects.forEach((subject) => {
+  const tile = document.createElement('button');
+  tile.type = 'button';
+  tile.className = 'tile subject';
+  tile.dataset.moduleCode = subject.code;
+  tile.textContent = subject.name;
+  tile.addEventListener('click', () => startSubject(subject.code));
+  elSubj?.appendChild(tile);
+});
+
+if (btnStartCore && modules.core.subtests.length) {
+  btnStartCore.addEventListener('click', () => {
+    const firstCode = modules.core.subtests[0].code;
+    startCore(firstCode);
+  });
+}
+
+function ensureAccessOrNotify(code) {
+  if (canAccessModule(code)) return true;
+  alert(guardMessage(code));
+  return false;
+}
+
+async function startCore(code) {
+  if (!ensureAccessOrNotify(code)) return;
+
+  if (code === 'CORE-FIG') {
+    window.location.href = './core/figural/';
+    return;
+  }
+  if (code === 'CORE-MATH') {
+    window.location.href = './core/math/';
+    return;
+  }
+  if (code === 'CORE-LAT') {
+    window.location.href = './core/latin/';
+    return;
+  }
+
+  const url = URLS.core[code];
+  if (!url) {
+    alert('Subtest not set up yet.');
+    return;
+  }
+  const data = await fetchJSON(url);
+  runQuiz(data.subtest, data.questions, { mode: 'core' });
+}
+
+async function startSubject(code) {
+  if (code === 'MED') {
+    window.location.href = './subjects/medicine/';
+    return;
+  }
+  const url = URLS.subjects[code];
+  if (!url) {
+    alert('Subject not set up yet.');
+    return;
+  }
+  const data = await fetchJSON(url);
+  const questions = shuffle(data.questions);
+  runQuiz(data.subject, questions, { mode: 'subject' });
+}
+
+function runQuiz(title, questions, opts) {
+  const container = document.querySelector('.page');
+  if (!container) return;
+  container.innerHTML = `
+    <div class="wrap">
+      <header style="display:flex;align-items:center;gap:12px;margin:30px 0 10px 0;">
+        <span class="dot" style="width:12px;height:12px;border-radius:50%;background:var(--sf-red);"></span>
+        <div class="brand" style="font-weight:700;font-size:18px;">
+          Study Feeds • TestAS Practice
+        </div>
+        <span class="tag" style="margin-left:auto;background:var(--sf-red);color:#fff;padding:6px 12px;border-radius:999px;font-size:12px;font-weight:600;">
+          ${opts.mode === 'core' ? 'Core' : 'Subject'}
+        </span>
+      </header>
+    </div>
+    <section class="wrap hero" style="margin-bottom:30px;">
+      <div class="hero-content">
+        <h1 style="font-size:32px;">${title.replace('CORE-', '')}</h1>
+        <p class="muted" style="color:var(--sf-muted);">Question <span id="p-count">1</span> / ${questions.length}</p>
+        <div class="hero-actions">
+          <button class="btn" id="btn-back">← Back to Modules</button>
+        </div>
+      </div>
+      <div class="hero-visual" style="justify-content:center;">
+        <div class="stat" style="background:#fff;border-radius:16px;padding:22px 24px;box-shadow:var(--shadow-soft);">
+          <strong style="font-size:28px;color:var(--sf-dark);">Stay focused</strong>
+          <span>Work through one task at a time and review the explanation afterwards.</span>
+        </div>
+      </div>
+    </section>
+    <section class="wrap section" style="margin-top:0;">
+      <div class="module-panel" style="box-shadow:var(--shadow-soft);">
+        <div id="quiz"></div>
+      </div>
+    </section>
+    <footer style="margin:60px 0 30px;text-align:center;font-size:13px;color:var(--sf-muted);">
+      © ${new Date().getFullYear()} Study Feeds Practice
+    </footer>
+  `;
+  document.getElementById('btn-back').onclick = () => (window.location.href = './');
+
+  let index = 0;
+  let correct = 0;
+  const review = [];
+  const mount = document.getElementById('quiz');
+  renderQuestion();
+
+  function renderQuestion(showExplanation = false) {
+    const question = questions[index];
+    document.getElementById('p-count').textContent = index + 1;
+    mount.innerHTML = `
+      <p style="font-weight:600;margin:0 0 8px 0;">${question.stem}</p>
+      ${question.image_url ? `<img src="${question.image_url}" alt="" style="max-width:100%;border:1px solid #eee;border-radius:12px;margin:12px 0;">` : ''}
+      <div style="display:grid;gap:12px;">
+        ${question.choices
+          .map(
+            (choice) => `
+              <button class="btn" data-choice="${choice.label}">
+                ${choice.label ? `<strong>${choice.label}.</strong> ` : ''}${choice.text}
+              </button>
+            `
+          )
+          .join('')}
+      </div>
+      ${
+        showExplanation
+          ? `
+        <div class="feature-card" style="margin-top:16px;background:#fff4f4;border:1px solid rgba(227,6,19,.18);">
+          <strong>Explanation</strong><br>${question.explanation || '—'}
+        </div>`
+          : ''
+      }
+    `;
+
+    mount.querySelectorAll('button[data-choice]').forEach((button) => {
+      button.onclick = () => {
+        const choice = question.choices.find((item) => item.label === button.dataset.choice);
+        const isCorrect = Boolean(choice?.is_correct);
+        if (isCorrect) correct += 1;
+        review.push({
+          stem: question.stem,
+          choice: choice?.label,
+          ok: isCorrect,
+          explanation: question.explanation,
+        });
+        renderQuestion(true);
+        setTimeout(() => {
+          index += 1;
+          if (index >= questions.length) {
+            renderResults();
+          } else {
+            renderQuestion();
+          }
+        }, 750);
+      };
+    });
+  }
+
+  function renderResults() {
+    mount.innerHTML = `
+      <div style="text-align:center;display:grid;gap:18px;">
+        <div>
+          <h3 style="margin:0 0 6px 0;">Result</h3>
+          <p style="margin:0;">You answered <strong>${correct}</strong> out of ${questions.length} correctly.</p>
+        </div>
+        <div class="hero-actions" style="justify-content:center;">
+          <button class="btn btn-primary" id="btn-review">Review explanations</button>
+          <button class="btn" id="btn-home">Back to Modules</button>
+        </div>
+      </div>
+    `;
+    document.getElementById('btn-home').onclick = () => (window.location.href = './');
+    document.getElementById('btn-review').onclick = () => {
+      mount.innerHTML = `
+        ${review
+          .map(
+            (entry) => `
+              <div class="feature-card" style="margin-bottom:12px;">
+                <p style="margin:0 0 6px 0;">${entry.stem}</p>
+                <p class="muted" style="margin:0 0 6px 0;color:${entry.ok ? '#0f5132' : '#842029'};">
+                  ${entry.ok ? '✅ Correct' : '❌ Wrong'} — Your choice: ${entry.choice ?? '—'}
+                </p>
+                <div>${entry.explanation || '—'}</div>
+              </div>
+            `
+          )
+          .join('')}
+        <div class="hero-actions" style="margin-top:16px;">
+          <button class="btn" onclick="location.href='./'">Back to Modules</button>
+        </div>
+      `;
+    };
+  }
+}

--- a/scripts/user-directory.js
+++ b/scripts/user-directory.js
@@ -1,0 +1,52 @@
+const DIRECTORY_URL = new URL('../data/userDirectory.json', import.meta.url);
+
+let directoryCache = null;
+let directoryPromise = null;
+
+export async function getUserDirectory() {
+  if (directoryCache) return directoryCache;
+  if (!directoryPromise) {
+    directoryPromise = fetch(DIRECTORY_URL, { cache: 'no-store' })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Unable to load user directory (HTTP ${response.status})`);
+        }
+        const payload = await response.json();
+        if (!payload || typeof payload !== 'object') {
+          throw new Error('User directory response was not valid JSON.');
+        }
+        directoryCache = normalizeDirectory(payload);
+        return directoryCache;
+      })
+      .catch((error) => {
+        directoryPromise = null;
+        throw error;
+      });
+  }
+  return directoryPromise;
+}
+
+function normalizeDirectory(raw) {
+  const users = Array.isArray(raw.users) ? raw.users : [];
+  return {
+    adminId: raw.adminId ?? null,
+    users: users.map((entry) => ({
+      uid: entry.uid ?? null,
+      email: entry.email ?? null,
+      role: entry.role ?? null,
+      displayName: entry.displayName ?? null,
+    })),
+  };
+}
+
+export function findDirectoryEntry(user, directory) {
+  if (!user || !directory) return null;
+  const { users = [] } = directory;
+  if (!users.length) return null;
+
+  return (
+    users.find((entry) => entry.uid && entry.uid === user.uid) ||
+    users.find((entry) => entry.email && user.email && entry.email.toLowerCase() === user.email.toLowerCase()) ||
+    null
+  );
+}


### PR DESCRIPTION
## Summary
- integrate Firebase authentication helpers, shared controller, and a persistent user directory for role lookup
- update the home page and navigation to surface sign-in/out controls, persist auth state, and expose admin indicators
- guard the figural module behind member+ roles with role-aware UI while wiring protected pages to the shared auth logic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68f1502b63488330b53a76839046a6f9